### PR TITLE
Mob registration link qr

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "TimelyOne",
     "slug": "salonix-mobile",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/docs/superpowers/plans/2026-07-17-mob-registration-link-qr.md
+++ b/docs/superpowers/plans/2026-07-17-mob-registration-link-qr.md
@@ -1,0 +1,578 @@
+# Link de Registo + QR Code no MOB Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adicionar ao MOB (`CustomersScreen.tsx`) a capacidade de partilhar o link de auto-cadastro do tenant (`/join/:tenantSlug`) e gerar um QR Code apontando para ele — paridade com o que já existe em FEW (`Customers.jsx`).
+
+**Architecture:** Duas novas funções em `src/utils/env.js` (`getWebOrigin`, `getRegistrationLink`) resolvem o link por ambiente, seguindo o padrão já existente de `getResetUrl()`. Um novo componente `ShareRegistrationLinkModal.tsx` (mesmo padrão visual de `ImportCustomersModal.tsx`) mostra o QR Code + link + botão copiar. `CustomersScreen.tsx` ganha dois botões novos na barra de ações, ao lado do "Importar/Exportar" já existente: "Partilhar link" (usa `Share.share()` nativo) e "Gerar QR Code" (abre o modal). Nenhum dos dois é restrito a owner — o FEW não restringe estes botões por papel, então o MOB segue a mesma paridade.
+
+**Tech Stack:** React Native, Expo, `react-native-qrcode-svg` (novo), `expo-clipboard` (novo), Jest + `@testing-library/react-native`.
+
+---
+
+### Task 1: `getWebOrigin` e `getRegistrationLink` em `src/utils/env.js`
+
+**Files:**
+- Modify: `src/utils/env.js`
+- Test: `src/utils/__tests__/env.test.js`
+
+- [ ] **Step 1: Adicionar os testes ao ficheiro existente**
+
+`src/utils/__tests__/env.test.js` já existe e testa `resolveMediaUrl`. Adicionar no final do ficheiro (mantendo o `require` no topo, mas trocando para importar também as novas funções):
+
+Substituir a linha 1 (`const { resolveMediaUrl } = require('../env');`) por:
+
+```js
+const { resolveMediaUrl, getWebOrigin, getRegistrationLink } = require('../env');
+```
+
+E adicionar, depois do `describe('resolveMediaUrl', ...)` já existente:
+
+```js
+describe('getWebOrigin', () => {
+  const originalEnv = process.env.WEB_ORIGIN;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.WEB_ORIGIN;
+    } else {
+      process.env.WEB_ORIGIN = originalEnv;
+    }
+  });
+
+  it('returns the WEB_ORIGIN env var when set, without a trailing slash', () => {
+    process.env.WEB_ORIGIN = 'https://custom.example.com/';
+    expect(getWebOrigin('https://irrelevant/api/')).toBe('https://custom.example.com');
+  });
+
+  it('returns localhost:5173 for a local dev API base', () => {
+    delete process.env.WEB_ORIGIN;
+    expect(getWebOrigin('http://0.0.0.0:8000/api/')).toBe('http://localhost:5173');
+    expect(getWebOrigin('http://192.168.0.203:8000/api/')).toBe('http://localhost:5173');
+  });
+
+  it('returns the staging web origin for the staging API base', () => {
+    delete process.env.WEB_ORIGIN;
+    expect(getWebOrigin('https://timelyonestaging.pythonanywhere.com/api/')).toBe(
+      'https://timelyone-staging.vercel.app'
+    );
+  });
+
+  it('returns the production web origin for the production API base', () => {
+    delete process.env.WEB_ORIGIN;
+    expect(getWebOrigin('https://salonix-backend-production.up.railway.app/api/')).toBe(
+      'https://timelyone.today'
+    );
+  });
+});
+
+describe('getRegistrationLink', () => {
+  afterEach(() => {
+    delete process.env.WEB_ORIGIN;
+  });
+
+  it('builds the join link from the web origin and tenant slug', () => {
+    expect(
+      getRegistrationLink('acme', 'https://salonix-backend-production.up.railway.app/api/')
+    ).toBe('https://timelyone.today/join/acme');
+  });
+
+  it('respects the WEB_ORIGIN env var override', () => {
+    process.env.WEB_ORIGIN = 'https://custom.example.com';
+    expect(getRegistrationLink('acme', 'https://irrelevant/api/')).toBe(
+      'https://custom.example.com/join/acme'
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Rodar os testes para confirmar que falham**
+
+Run: `npx jest src/utils/__tests__/env.test.js --watchAll=false`
+Expected: FAIL com `getWebOrigin is not a function` / `getRegistrationLink is not a function`.
+
+- [ ] **Step 3: Implementar `getWebOrigin` e `getRegistrationLink`**
+
+Em `src/utils/env.js`, adicionar depois de `getResetUrl` (antes de `export const API_BASE_URL = getApiBaseUrl();`):
+
+```js
+export function getWebOrigin(apiBase = getApiBaseUrl()) {
+  const envWebOrigin = getEnvVar("WEB_ORIGIN");
+  if (envWebOrigin) {
+    return envWebOrigin.endsWith("/") ? envWebOrigin.slice(0, -1) : envWebOrigin;
+  }
+
+  if (
+    apiBase.includes("localhost") ||
+    apiBase.includes("0.0.0.0") ||
+    apiBase.includes("192.168")
+  ) {
+    return "http://localhost:5173";
+  }
+
+  if (apiBase.includes("timelyonestaging.pythonanywhere.com")) {
+    return "https://timelyone-staging.vercel.app";
+  }
+
+  return "https://timelyone.today";
+}
+
+export function getRegistrationLink(slug, apiBase = getApiBaseUrl()) {
+  return `${getWebOrigin(apiBase)}/join/${slug}`;
+}
+```
+
+- [ ] **Step 4: Rodar os testes para confirmar que passam**
+
+Run: `npx jest src/utils/__tests__/env.test.js --watchAll=false`
+Expected: PASS (9 testes: 5 já existentes de `resolveMediaUrl` + 4 novos de `getWebOrigin` + 2 de `getRegistrationLink` = 11 no total).
+
+- [ ] **Step 5: Não commitar**
+
+O Pablo faz commit/push manualmente. Não correr `git add`/`git commit`.
+
+---
+
+### Task 2: Instalar dependências de QR Code e clipboard
+
+**Files:**
+- Modify: `package.json`, `package-lock.json`
+
+- [ ] **Step 1: Instalar as dependências via `expo install`**
+
+Run (a partir da raiz de `salonix-mobile`):
+
+```bash
+npx expo install react-native-qrcode-svg react-native-svg expo-clipboard
+```
+
+Expected: `package.json` ganha as 3 novas entradas em `dependencies`, versões compatíveis com o SDK do Expo instalado no projeto (o `expo install`, ao contrário de `npm install`, resolve a versão correta automaticamente).
+
+- [ ] **Step 2: Confirmar que a instalação não quebrou nada**
+
+Run: `npx jest --watchAll=false`
+Expected: PASS (mesma contagem de testes de antes da instalação — nenhum teste depende ainda destas libs).
+
+- [ ] **Step 3: Não commitar**
+
+---
+
+### Task 3: Componente `ShareRegistrationLinkModal.tsx`
+
+**Files:**
+- Create: `src/components/ShareRegistrationLinkModal.tsx`
+- Test: `src/components/__tests__/ShareRegistrationLinkModal.test.tsx`
+
+- [ ] **Step 1: Escrever o teste (falhando)**
+
+```tsx
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+import { ShareRegistrationLinkModal } from '../ShareRegistrationLinkModal';
+
+jest.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      textPrimary: '#000',
+      textSecondary: '#666',
+      border: '#ccc',
+      brandPrimary: '#3b82f6',
+      background: '#fff',
+      surface: '#f8fafc',
+      surfaceVariant: '#eee',
+      error: '#ef4444',
+    },
+  }),
+}));
+
+jest.mock('react-native-qrcode-svg', () => {
+  const { View } = require('react-native');
+  return ({ value }: { value: string }) => <View testID="qr-code" accessibilityLabel={value} />;
+});
+
+const mockSetStringAsync = jest.fn();
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: (...args: any[]) => mockSetStringAsync(...args),
+}));
+
+jest.mock('../../utils/env', () => ({
+  getRegistrationLink: (slug: string) => `https://timelyone.today/join/${slug}`,
+}));
+
+describe('ShareRegistrationLinkModal', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders the QR code and link for the given slug', () => {
+    const { getByTestId, getByText } = render(
+      <ShareRegistrationLinkModal visible onClose={jest.fn()} slug="acme" />
+    );
+
+    expect(getByTestId('qr-code').props.accessibilityLabel).toBe(
+      'https://timelyone.today/join/acme'
+    );
+    expect(getByText('https://timelyone.today/join/acme')).toBeTruthy();
+  });
+
+  it('copies the link to the clipboard when "Copiar link" is pressed', async () => {
+    jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const { getByText } = render(
+      <ShareRegistrationLinkModal visible onClose={jest.fn()} slug="acme" />
+    );
+
+    await fireEvent.press(getByText('Copiar link'));
+
+    await waitFor(() => {
+      expect(mockSetStringAsync).toHaveBeenCalledWith('https://timelyone.today/join/acme');
+    });
+  });
+
+  it('calls onClose when "Fechar" is pressed', () => {
+    const onClose = jest.fn();
+    const { getByText } = render(
+      <ShareRegistrationLinkModal visible onClose={onClose} slug="acme" />
+    );
+
+    fireEvent.press(getByText('Fechar'));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Rodar o teste para confirmar que falha**
+
+Run: `npx jest src/components/__tests__/ShareRegistrationLinkModal.test.tsx --watchAll=false`
+Expected: FAIL — `Cannot find module '../ShareRegistrationLinkModal'`.
+
+- [ ] **Step 3: Implementar o componente**
+
+```tsx
+import React from 'react';
+import { View, Text, StyleSheet, Alert } from 'react-native';
+import QRCode from 'react-native-qrcode-svg';
+import * as Clipboard from 'expo-clipboard';
+import { Button } from './ui/Button';
+import { Modal } from './ui/Modal';
+import { useTheme } from '../hooks/useTheme';
+import { getRegistrationLink } from '../utils/env';
+
+interface ShareRegistrationLinkModalProps {
+  visible: boolean;
+  onClose: () => void;
+  slug?: string;
+}
+
+export function ShareRegistrationLinkModal({
+  visible,
+  onClose,
+  slug,
+}: ShareRegistrationLinkModalProps) {
+  const { colors } = useTheme();
+  const link = slug ? getRegistrationLink(slug) : '';
+
+  const handleCopy = async () => {
+    try {
+      await Clipboard.setStringAsync(link);
+      Alert.alert('Copiado', 'Link copiado para a área de transferência.');
+    } catch (error) {
+      console.error('Error copying registration link:', error);
+      Alert.alert('Erro', 'Não foi possível copiar o link.');
+    }
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      onClose={onClose}
+      title="QR Code de registo"
+      footer={
+        <Button onPress={onClose} style={{ flex: 1 }}>
+          Fechar
+        </Button>
+      }
+    >
+      <View style={styles.content}>
+        {link ? (
+          <>
+            <View style={styles.qrWrapper}>
+              <QRCode value={link} size={220} />
+            </View>
+            <Text
+              style={{
+                color: colors.textSecondary,
+                fontSize: 13,
+                textAlign: 'center',
+                marginBottom: 12,
+              }}
+            >
+              {link}
+            </Text>
+            <Button variant="secondary" onPress={handleCopy}>
+              Copiar link
+            </Button>
+          </>
+        ) : (
+          <Text style={{ color: colors.textSecondary }}>Link indisponível.</Text>
+        )}
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    alignItems: 'center',
+  },
+  qrWrapper: {
+    marginBottom: 16,
+  },
+});
+```
+
+- [ ] **Step 4: Rodar o teste para confirmar que passa**
+
+Run: `npx jest src/components/__tests__/ShareRegistrationLinkModal.test.tsx --watchAll=false`
+Expected: PASS (3 testes).
+
+- [ ] **Step 5: Não commitar**
+
+---
+
+### Task 4: Botões "Partilhar link" e "Gerar QR Code" em `CustomersScreen.tsx`
+
+**Files:**
+- Modify: `src/screens/CustomersScreen.tsx`
+- Test: `src/screens/__tests__/CustomersScreen.shareLink.test.tsx`
+
+- [ ] **Step 1: Escrever o teste (falhando)**
+
+```tsx
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { Share } from 'react-native';
+import CustomersScreen from '../CustomersScreen';
+
+jest.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      textPrimary: '#000',
+      textSecondary: '#666',
+      border: '#ccc',
+      brandPrimary: '#3b82f6',
+      background: '#fff',
+      surface: '#f8fafc',
+      surfaceVariant: '#eee',
+      error: '#ef4444',
+    },
+  }),
+}));
+
+jest.mock('../../hooks/useTenant', () => ({
+  useTenant: () => ({ slug: 'acme' }),
+}));
+
+let mockUseAuthReturn: any = { userInfo: { id: 1, role: 'owner' } };
+jest.mock('../../hooks/useAuth', () => ({
+  useAuth: () => mockUseAuthReturn,
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+const mockFetchCustomers = jest.fn();
+jest.mock('../../api/customers', () => ({
+  fetchCustomers: (...args: any[]) => mockFetchCustomers(...args),
+  createCustomer: jest.fn(),
+  updateCustomer: jest.fn(),
+  deleteCustomer: jest.fn(),
+  resendCustomerInvite: jest.fn(),
+  exportCustomersCSV: jest.fn(),
+}));
+
+jest.mock('../../utils/csvFileSharing', () => ({
+  saveAndShareCSV: jest.fn(),
+}));
+
+jest.mock('../../components/ImportCustomersModal', () => ({
+  __esModule: true,
+  ImportCustomersModal: () => null,
+}));
+
+jest.mock('../../components/ShareRegistrationLinkModal', () => {
+  const { Text, Pressable } = require('react-native');
+  return {
+    __esModule: true,
+    ShareRegistrationLinkModal: ({ visible, onClose }: any) => {
+      if (!visible) return null;
+      return (
+        <Pressable onPress={onClose}>
+          <Text>qr-modal-stub</Text>
+        </Pressable>
+      );
+    },
+  };
+});
+
+jest.mock('../../utils/env', () => ({
+  getRegistrationLink: (slug: string) => `https://timelyone.today/join/${slug}`,
+}));
+
+describe('CustomersScreen - share registration link', () => {
+  beforeEach(() => {
+    mockUseAuthReturn = { userInfo: { id: 1, role: 'owner' } };
+    mockFetchCustomers.mockResolvedValue({ results: [], count: 0 });
+  });
+  afterEach(() => jest.clearAllMocks());
+
+  it('shares the registration link when "Partilhar link" is pressed', async () => {
+    jest.spyOn(Share, 'share').mockResolvedValue({ action: Share.sharedAction } as any);
+
+    const { getByText } = await render(<CustomersScreen />);
+    await waitFor(() => expect(mockFetchCustomers).toHaveBeenCalled());
+    await fireEvent.press(getByText('Partilhar link'));
+
+    await waitFor(() => {
+      expect(Share.share).toHaveBeenCalledWith({
+        message: 'https://timelyone.today/join/acme',
+      });
+    });
+  });
+
+  it('opens the QR code modal when "Gerar QR Code" is pressed', async () => {
+    const { getByText } = await render(<CustomersScreen />);
+    await waitFor(() => expect(mockFetchCustomers).toHaveBeenCalled());
+    await fireEvent.press(getByText('Gerar QR Code'));
+
+    await waitFor(() => {
+      expect(getByText('qr-modal-stub')).toBeTruthy();
+    });
+  });
+
+  it('shows "Partilhar link" and "Gerar QR Code" to non-owners too (sem gate de papel, igual ao FEW)', async () => {
+    mockUseAuthReturn = { userInfo: { id: 3, role: 'collaborator' } };
+
+    const { getByText } = await render(<CustomersScreen />);
+    await waitFor(() => expect(mockFetchCustomers).toHaveBeenCalled());
+
+    expect(getByText('Partilhar link')).toBeTruthy();
+    expect(getByText('Gerar QR Code')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Rodar o teste para confirmar que falha**
+
+Run: `npx jest src/screens/__tests__/CustomersScreen.shareLink.test.tsx --watchAll=false`
+Expected: FAIL — `Unable to find an element with text: Partilhar link`.
+
+- [ ] **Step 3: Adicionar os imports necessários**
+
+Em `src/screens/CustomersScreen.tsx`, na linha do import de `react-native` (linha 2), adicionar `Share` à lista já existente:
+
+```tsx
+import { View, Text, FlatList, RefreshControl, StyleSheet, TouchableOpacity, ActivityIndicator, Alert, ActionSheetIOS, Platform, Keyboard, Share } from 'react-native';
+```
+
+Depois do import de `ImportCustomersModal` (linha 9), adicionar:
+
+```tsx
+import { ShareRegistrationLinkModal } from '../components/ShareRegistrationLinkModal';
+import { getRegistrationLink } from '../utils/env';
+```
+
+- [ ] **Step 4: Adicionar o estado do modal**
+
+Junto aos outros `useState` já existentes (perto da linha 39, ao lado de `importModalVisible`):
+
+```tsx
+const [qrModalVisible, setQrModalVisible] = useState(false);
+```
+
+- [ ] **Step 5: Adicionar o handler de partilha**
+
+Perto de `handleImportExport` (depois dele):
+
+```tsx
+const handleShareLink = async () => {
+    try {
+      await Share.share({ message: getRegistrationLink(slug) });
+    } catch (error) {
+      console.error('Error sharing registration link:', error);
+    }
+};
+```
+
+- [ ] **Step 6: Adicionar os dois botões na barra de ações**
+
+Na `View` da barra de ações (depois do botão "Importar/Exportar", ainda dentro do bloco `isOwner(userInfo) && (...)` que o envolve — mas os dois botões novos ficam FORA desse bloco, sem gate de papel, para bater com o FEW):
+
+```tsx
+    {isOwner(userInfo) && (
+      <TouchableOpacity onPress={handleImportExport} style={{ flexDirection: 'row', alignItems: 'center' }}>
+          <Ionicons name="swap-vertical-outline" size={18} color={colors.textSecondary} />
+          <Text style={{ color: colors.textSecondary, fontSize: 13, fontWeight: '600', marginLeft: 6 }}>
+              Importar/Exportar
+          </Text>
+      </TouchableOpacity>
+    )}
+
+    <TouchableOpacity onPress={handleShareLink} style={{ flexDirection: 'row', alignItems: 'center' }}>
+        <Ionicons name="share-outline" size={18} color={colors.textSecondary} />
+        <Text style={{ color: colors.textSecondary, fontSize: 13, fontWeight: '600', marginLeft: 6 }}>
+            Partilhar link
+        </Text>
+    </TouchableOpacity>
+
+    <TouchableOpacity onPress={() => setQrModalVisible(true)} style={{ flexDirection: 'row', alignItems: 'center' }}>
+        <Ionicons name="qr-code-outline" size={18} color={colors.textSecondary} />
+        <Text style={{ color: colors.textSecondary, fontSize: 13, fontWeight: '600', marginLeft: 6 }}>
+            Gerar QR Code
+        </Text>
+    </TouchableOpacity>
+```
+
+- [ ] **Step 7: Montar o modal**
+
+Depois de `<ImportCustomersModal .../>` (perto da linha 400):
+
+```tsx
+<ShareRegistrationLinkModal
+    visible={qrModalVisible}
+    onClose={() => setQrModalVisible(false)}
+    slug={slug}
+/>
+```
+
+- [ ] **Step 8: Rodar o teste para confirmar que passa**
+
+Run: `npx jest src/screens/__tests__/CustomersScreen.shareLink.test.tsx --watchAll=false`
+Expected: PASS (3 testes).
+
+- [ ] **Step 9: Rodar o teste de import/export já existente para confirmar que não quebrou**
+
+Run: `npx jest src/screens/__tests__/CustomersScreen.importExport.test.tsx --watchAll=false`
+Expected: PASS (3 testes, sem alteração).
+
+- [ ] **Step 10: Não commitar**
+
+---
+
+### Task 5: Varredura completa
+
+**Files:** nenhum (apenas verificação)
+
+- [ ] **Step 1: Rodar toda a suíte de testes**
+
+Run: `npx jest --watchAll=false`
+Expected: PASS em todos os testes (nenhuma regressão face ao estado antes deste plano).
+
+- [ ] **Step 2: Rodar o TypeScript type-check**
+
+Run: `npx tsc --noEmit`
+Expected: nenhum erro novo nos ficheiros deste plano (`ShareRegistrationLinkModal.tsx`, `CustomersScreen.tsx`; `env.js` é JS puro, sem tipos a verificar). **Nota:** o repo já tem erros de `tsc` pré-existentes e não relacionados, em ficheiros de teste antigos (`professionalColor.test.ts`, `zipFileSharing.test.ts` — faltam tipos globais do Jest). Não é preciso corrigir isso aqui; apenas confirmar que nenhum erro novo aparece nos ficheiros tocados por este plano.
+
+- [ ] **Step 3: Não commitar**
+
+Reportar ao Pablo a contagem final de testes e confirmar que está tudo verde. Ele faz o commit/push manualmente.

--- a/docs/superpowers/specs/2026-07-17-mob-registration-link-qr-design.md
+++ b/docs/superpowers/specs/2026-07-17-mob-registration-link-qr-design.md
@@ -1,0 +1,75 @@
+# Link de Registo + QR Code no MOB — Design
+
+**Repo afetado:** `salonix-mobile` (branch `mob-registration-link-qr`)
+
+## Contexto
+
+O FEW (`salonix-frontend-web`) tem, na página de Clientes (`Customers.jsx`), a
+capacidade de gerar um link de auto-cadastro (`/join/:tenantSlug`) e um QR
+Code apontando para esse link, para o dono do salão partilhar com clientes
+(imprimir, publicar no Instagram, etc.). Essa funcionalidade ficou de fora do
+MOB (`CustomersScreen.tsx`) na paridade feita em `86-mob-parity-01` — o Pablo
+já lançou o build atual sem ela e vai precisar de um novo lançamento para
+corrigir, daí este branch separado.
+
+## Regra
+
+Mesmo link do FEW (`{webOrigin}/join/{tenantSlug}`), sem deep link nativo —
+a rota `/join/:tenantSlug` é web (React), não existe equivalente nativo no
+MOB. O link sempre abre a página web no browser do telemóvel.
+
+## Onde
+
+`src/screens/CustomersScreen.tsx`, na barra de ações, ao lado do botão
+"Importar/Exportar" já existente (`handleImportExport`).
+
+## Componentes
+
+**Botão "Partilhar link"** — usa a API `Share` nativa do React Native
+(`Share.share({ message: link })`), abrindo o menu de partilha do sistema
+(WhatsApp, SMS, Instagram, etc.) já com o link preenchido. Ação principal,
+sem passos extra.
+
+**Botão "Gerar QR Code"** — abre um modal (mesmo padrão visual de
+`CustomerFormModal`/`ImportCustomersModal`) com:
+- QR Code do link, via `react-native-qrcode-svg` (equivalente do
+  `qrcode.react` usado no FEW, mesma API: `value`, `size`).
+- Texto do link por baixo.
+- Botão "Copiar link" (usa `expo-clipboard`, já uma dependência do projeto)
+  como alternativa dentro do modal.
+
+## Construção do link
+
+Nova função `getWebOrigin()` em `src/utils/env.js`, seguindo exatamente o
+mesmo padrão já usado por `getResetUrl()` nesse ficheiro (fallback por
+ambiente: dev → localhost:5173, staging → domínio de staging, produção →
+domínio de produção do FEW). O `tenantSlug` vem do hook `useTenant()`, já
+usado noutros ecrãs do MOB.
+
+```js
+export function getWebOrigin() {
+  const apiBase = getApiBaseUrl();
+  if (apiBase.includes("localhost") || apiBase.includes("0.0.0.0") || apiBase.includes("192.168")) {
+    return "http://localhost:5173";
+  }
+  if (apiBase.includes("timelyonestaging.pythonanywhere.com")) {
+    return "https://timelyone-staging.vercel.app";
+  }
+  return "https://timelyone.today"; // domínio de produção do FEW, confirmado pelo Pablo
+}
+```
+
+## Testes
+
+Jest, mesmo padrão do resto do MOB:
+- `getWebOrigin()` devolve o domínio certo para cada ambiente (dev/staging/produção).
+- Link final é `{webOrigin}/join/{tenantSlug}` com o slug correto.
+- `Share.share` é chamado com o link correto ao tocar em "Partilhar link".
+- Modal do QR abre/fecha corretamente.
+- "Copiar link" dentro do modal chama `expo-clipboard` com o link correto.
+
+## Fora de escopo
+
+- Deep link nativo (abrir o registo dentro do próprio app) — mantém-se como
+  página web, igual ao FEW.
+- Alterar o comportamento do FEW — este trabalho é só paridade no MOB.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "expo": "^54.0.33",
         "expo-asset": "~12.0.12",
         "expo-build-properties": "~1.0.10",
+        "expo-clipboard": "~8.0.8",
         "expo-constants": "~18.0.13",
         "expo-device": "~8.0.10",
         "expo-document-picker": "~14.0.8",
@@ -36,8 +37,10 @@
         "nativewind": "^4.2.1",
         "react": "19.1.0",
         "react-native": "0.81.5",
+        "react-native-qrcode-svg": "^6.3.21",
         "react-native-safe-area-context": "~5.6.0",
-        "react-native-screens": "~4.16.0"
+        "react-native-screens": "~4.16.0",
+        "react-native-svg": "15.12.1"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -3560,6 +3563,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
@@ -4151,6 +4160,56 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -4224,6 +4283,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
@@ -4381,10 +4449,54 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -4408,6 +4520,35 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -4883,6 +5024,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-clipboard": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-8.0.8.tgz",
+      "integrity": "sha512-VKoBkHIpZZDJTB0jRO4/PZskHdMNOEz3P/41tmM6fDuODMpqhvyWK053X0ebspkxiawJX9lX33JXHBCvVsTTOA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-constants": {
@@ -7949,6 +8101,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "license": "CC0-1.0"
+    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -8501,6 +8659,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nullthrows": {
@@ -9201,6 +9371,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -9244,12 +9431,113 @@
       ],
       "license": "MIT"
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/qrcode-terminal": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.11.0.tgz",
       "integrity": "sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==",
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/qrcode/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/query-string": {
@@ -9708,6 +9996,22 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-qrcode-svg": {
+      "version": "6.3.21",
+      "resolved": "https://registry.npmjs.org/react-native-qrcode-svg/-/react-native-qrcode-svg-6.3.21.tgz",
+      "integrity": "sha512-6vcj4rcdpWedvphDR+NSJcudJykNuLgNGFwm2p4xYjR8RdyTzlrELKI5LkO4ANS9cQUbqsfkpippPv64Q2tUtA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.0",
+        "qrcode": "^1.5.4",
+        "text-encoding": "^0.7.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">=0.63.4",
+        "react-native-svg": ">=14.0.0"
+      }
+    },
     "node_modules/react-native-reanimated": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.2.1.tgz",
@@ -9752,6 +10056,21 @@
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-svg": {
+      "version": "15.12.1",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
+      "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3",
+        "warn-once": "0.1.1"
       },
       "peerDependencies": {
         "react": "*",
@@ -10083,6 +10402,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
     "node_modules/requireg": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/requireg/-/requireg-0.2.2.tgz",
@@ -10408,6 +10733,12 @@
       "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -11013,6 +11344,13 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/text-encoding": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
+      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==",
+      "deprecated": "no longer maintained",
+      "license": "(Unlicense OR Apache-2.0)"
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -11515,6 +11853,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.20",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "expo": "^54.0.33",
     "expo-asset": "~12.0.12",
     "expo-build-properties": "~1.0.10",
+    "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.13",
     "expo-device": "~8.0.10",
     "expo-document-picker": "~14.0.8",
@@ -38,8 +39,10 @@
     "nativewind": "^4.2.1",
     "react": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-qrcode-svg": "^6.3.21",
     "react-native-safe-area-context": "~5.6.0",
-    "react-native-screens": "~4.16.0"
+    "react-native-screens": "~4.16.0",
+    "react-native-svg": "15.12.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/components/ShareRegistrationLinkModal.tsx
+++ b/src/components/ShareRegistrationLinkModal.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { View, Text, StyleSheet, Alert } from 'react-native';
+import QRCode from 'react-native-qrcode-svg';
+import * as Clipboard from 'expo-clipboard';
+import { Button } from './ui/Button';
+import { Modal } from './ui/Modal';
+import { useTheme } from '../hooks/useTheme';
+import { getRegistrationLink } from '../utils/env';
+
+interface ShareRegistrationLinkModalProps {
+  visible: boolean;
+  onClose: () => void;
+  slug?: string;
+}
+
+export function ShareRegistrationLinkModal({
+  visible,
+  onClose,
+  slug,
+}: ShareRegistrationLinkModalProps) {
+  const { colors } = useTheme();
+  const link = slug ? getRegistrationLink(slug) : '';
+
+  const handleCopy = async () => {
+    try {
+      await Clipboard.setStringAsync(link);
+      Alert.alert('Copiado', 'Link copiado para a área de transferência.');
+    } catch (error) {
+      console.error('Error copying registration link:', error);
+      Alert.alert('Erro', 'Não foi possível copiar o link.');
+    }
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      onClose={onClose}
+      title="QR Code de registo"
+      footer={
+        <Button onPress={onClose} style={{ flex: 1 }}>
+          Fechar
+        </Button>
+      }
+    >
+      <View style={styles.content}>
+        {link ? (
+          <>
+            <View style={styles.qrWrapper}>
+              <QRCode value={link} size={220} />
+            </View>
+            <Text
+              style={{
+                color: colors.textSecondary,
+                fontSize: 13,
+                textAlign: 'center',
+                marginBottom: 12,
+              }}
+            >
+              {link}
+            </Text>
+            <Button variant="secondary" onPress={handleCopy}>
+              Copiar link
+            </Button>
+          </>
+        ) : (
+          <Text style={{ color: colors.textSecondary }}>Link indisponível.</Text>
+        )}
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    alignItems: 'center',
+  },
+  qrWrapper: {
+    marginBottom: 16,
+  },
+});

--- a/src/components/__tests__/ShareRegistrationLinkModal.test.tsx
+++ b/src/components/__tests__/ShareRegistrationLinkModal.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+import { ShareRegistrationLinkModal } from '../ShareRegistrationLinkModal';
+
+jest.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      textPrimary: '#000',
+      textSecondary: '#666',
+      border: '#ccc',
+      brandPrimary: '#3b82f6',
+      background: '#fff',
+      surface: '#f8fafc',
+      surfaceVariant: '#eee',
+      error: '#ef4444',
+    },
+  }),
+}));
+
+jest.mock('react-native-qrcode-svg', () => {
+  const { View } = require('react-native');
+  return ({ value }: { value: string }) => <View testID="qr-code" accessibilityLabel={value} />;
+});
+
+const mockSetStringAsync = jest.fn();
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: (...args: any[]) => mockSetStringAsync(...args),
+}));
+
+jest.mock('../../utils/env', () => ({
+  getRegistrationLink: (slug: string) => `https://timelyone.today/join/${slug}`,
+}));
+
+describe('ShareRegistrationLinkModal', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders the QR code and link for the given slug', async () => {
+    const { getByTestId, getByText } = await render(
+      <ShareRegistrationLinkModal visible onClose={jest.fn()} slug="acme" />
+    );
+
+    expect(getByTestId('qr-code').props.accessibilityLabel).toBe(
+      'https://timelyone.today/join/acme'
+    );
+    expect(getByText('https://timelyone.today/join/acme')).toBeTruthy();
+  });
+
+  it('copies the link to the clipboard when "Copiar link" is pressed', async () => {
+    jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const { getByText } = await render(
+      <ShareRegistrationLinkModal visible onClose={jest.fn()} slug="acme" />
+    );
+
+    await fireEvent.press(getByText('Copiar link'));
+
+    await waitFor(() => {
+      expect(mockSetStringAsync).toHaveBeenCalledWith('https://timelyone.today/join/acme');
+    });
+  });
+
+  it('calls onClose when "Fechar" is pressed', async () => {
+    const onClose = jest.fn();
+    const { getByText } = await render(
+      <ShareRegistrationLinkModal visible onClose={onClose} slug="acme" />
+    );
+
+    fireEvent.press(getByText('Fechar'));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/screens/CustomersScreen.tsx
+++ b/src/screens/CustomersScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { View, Text, FlatList, RefreshControl, StyleSheet, TouchableOpacity, ActivityIndicator, Alert, ActionSheetIOS, Platform, Keyboard } from 'react-native';
+import { View, Text, FlatList, RefreshControl, StyleSheet, TouchableOpacity, ActivityIndicator, Alert, ActionSheetIOS, Platform, Keyboard, Share, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
@@ -9,7 +9,9 @@ import { Card } from '../components/ui/Card';
 import { fetchCustomers, createCustomer, updateCustomer, deleteCustomer, resendCustomerInvite, exportCustomersCSV } from '../api/customers';
 import { CustomerFormModal } from '../components/CustomerFormModal';
 import { ImportCustomersModal } from '../components/ImportCustomersModal';
+import { ShareRegistrationLinkModal } from '../components/ShareRegistrationLinkModal';
 import { saveAndShareCSV } from '../utils/csvFileSharing';
+import { getRegistrationLink } from '../utils/env';
 import { useTenant } from '../hooks/useTenant';
 import { useAuth } from '../hooks/useAuth';
 import { isOwner } from '../utils/permissions';
@@ -38,6 +40,7 @@ export default function CustomersScreen() {
     const [selectedCustomer, setSelectedCustomer] = useState<any>(null);
     const [actionLoading, setActionLoading] = useState(false);
     const [importModalVisible, setImportModalVisible] = useState(false);
+    const [qrModalVisible, setQrModalVisible] = useState(false);
 
     const handleExportCSV = async () => {
         try {
@@ -59,6 +62,14 @@ export default function CustomersScreen() {
 
     const handleImportSuccess = () => {
         loadCustomers(true);
+    };
+
+    const handleShareLink = async () => {
+        try {
+            await Share.share({ message: getRegistrationLink(slug) });
+        } catch (error) {
+            console.error('Error sharing registration link:', error);
+        }
     };
 
     const LIMIT = 20;
@@ -277,7 +288,11 @@ export default function CustomersScreen() {
                         {totalCount} clientes
                     </Text>
 
-                    <View style={{ flexDirection: 'row', marginTop: 12, gap: 16 }}>
+                    <ScrollView
+                        horizontal
+                        showsHorizontalScrollIndicator={false}
+                        contentContainerStyle={{ flexDirection: 'row', marginTop: 12, gap: 16 }}
+                    >
                         <TouchableOpacity
                             onPress={() => setShowFilters(!showFilters)}
                             style={{ flexDirection: 'row', alignItems: 'center' }}
@@ -328,7 +343,37 @@ export default function CustomersScreen() {
                               </Text>
                           </TouchableOpacity>
                         )}
-                    </View>
+
+                        <TouchableOpacity
+                            onPress={handleShareLink}
+                            style={{ flexDirection: 'row', alignItems: 'center' }}
+                        >
+                            <Ionicons name="share-outline" size={18} color={colors.textSecondary} />
+                            <Text style={{
+                                color: colors.textSecondary,
+                                fontSize: 13,
+                                fontWeight: '600',
+                                marginLeft: 6
+                            }}>
+                                Partilhar link
+                            </Text>
+                        </TouchableOpacity>
+
+                        <TouchableOpacity
+                            onPress={() => setQrModalVisible(true)}
+                            style={{ flexDirection: 'row', alignItems: 'center' }}
+                        >
+                            <Ionicons name="qr-code-outline" size={18} color={colors.textSecondary} />
+                            <Text style={{
+                                color: colors.textSecondary,
+                                fontSize: 13,
+                                fontWeight: '600',
+                                marginLeft: 6
+                            }}>
+                                Gerar QR Code
+                            </Text>
+                        </TouchableOpacity>
+                    </ScrollView>
                 </View>
             </View>
 
@@ -402,6 +447,12 @@ export default function CustomersScreen() {
                 visible={importModalVisible}
                 onClose={() => setImportModalVisible(false)}
                 onSuccess={handleImportSuccess}
+                slug={slug}
+            />
+
+            <ShareRegistrationLinkModal
+                visible={qrModalVisible}
+                onClose={() => setQrModalVisible(false)}
                 slug={slug}
             />
         </SafeAreaView>

--- a/src/screens/__tests__/CustomersScreen.shareLink.test.tsx
+++ b/src/screens/__tests__/CustomersScreen.shareLink.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { Share } from 'react-native';
+import CustomersScreen from '../CustomersScreen';
+
+jest.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      textPrimary: '#000',
+      textSecondary: '#666',
+      border: '#ccc',
+      brandPrimary: '#3b82f6',
+      background: '#fff',
+      surface: '#f8fafc',
+      surfaceVariant: '#eee',
+      error: '#ef4444',
+    },
+  }),
+}));
+
+jest.mock('../../hooks/useTenant', () => ({
+  useTenant: () => ({ slug: 'acme' }),
+}));
+
+let mockUseAuthReturn: any = { userInfo: { id: 1, role: 'owner' } };
+jest.mock('../../hooks/useAuth', () => ({
+  useAuth: () => mockUseAuthReturn,
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+const mockFetchCustomers = jest.fn();
+jest.mock('../../api/customers', () => ({
+  fetchCustomers: (...args: any[]) => mockFetchCustomers(...args),
+  createCustomer: jest.fn(),
+  updateCustomer: jest.fn(),
+  deleteCustomer: jest.fn(),
+  resendCustomerInvite: jest.fn(),
+  exportCustomersCSV: jest.fn(),
+}));
+
+jest.mock('../../utils/csvFileSharing', () => ({
+  saveAndShareCSV: jest.fn(),
+}));
+
+jest.mock('../../components/ImportCustomersModal', () => ({
+  __esModule: true,
+  ImportCustomersModal: () => null,
+}));
+
+jest.mock('../../components/ShareRegistrationLinkModal', () => {
+  const { Text, Pressable } = require('react-native');
+  return {
+    __esModule: true,
+    ShareRegistrationLinkModal: ({ visible, onClose }: any) => {
+      if (!visible) return null;
+      return (
+        <Pressable onPress={onClose}>
+          <Text>qr-modal-stub</Text>
+        </Pressable>
+      );
+    },
+  };
+});
+
+jest.mock('../../utils/env', () => ({
+  getRegistrationLink: (slug: string) => `https://timelyone.today/join/${slug}`,
+}));
+
+describe('CustomersScreen - share registration link', () => {
+  beforeEach(() => {
+    mockUseAuthReturn = { userInfo: { id: 1, role: 'owner' } };
+    mockFetchCustomers.mockResolvedValue({ results: [], count: 0 });
+  });
+  afterEach(() => jest.clearAllMocks());
+
+  it('shares the registration link when "Partilhar link" is pressed', async () => {
+    jest.spyOn(Share, 'share').mockResolvedValue({ action: Share.sharedAction } as any);
+
+    const { getByText } = await render(<CustomersScreen />);
+    await waitFor(() => expect(mockFetchCustomers).toHaveBeenCalled());
+    await fireEvent.press(getByText('Partilhar link'));
+
+    await waitFor(() => {
+      expect(Share.share).toHaveBeenCalledWith({
+        message: 'https://timelyone.today/join/acme',
+      });
+    });
+  });
+
+  it('opens the QR code modal when "Gerar QR Code" is pressed', async () => {
+    const { getByText } = await render(<CustomersScreen />);
+    await waitFor(() => expect(mockFetchCustomers).toHaveBeenCalled());
+    await fireEvent.press(getByText('Gerar QR Code'));
+
+    await waitFor(() => {
+      expect(getByText('qr-modal-stub')).toBeTruthy();
+    });
+  });
+
+  it('shows "Partilhar link" and "Gerar QR Code" to non-owners too (sem gate de papel, igual ao FEW)', async () => {
+    mockUseAuthReturn = { userInfo: { id: 3, role: 'collaborator' } };
+
+    const { getByText } = await render(<CustomersScreen />);
+    await waitFor(() => expect(mockFetchCustomers).toHaveBeenCalled());
+
+    expect(getByText('Partilhar link')).toBeTruthy();
+    expect(getByText('Gerar QR Code')).toBeTruthy();
+  });
+});

--- a/src/utils/__tests__/env.test.js
+++ b/src/utils/__tests__/env.test.js
@@ -1,4 +1,4 @@
-const { resolveMediaUrl } = require('../env');
+const { resolveMediaUrl, getWebOrigin, getRegistrationLink } = require('../env');
 
 describe('resolveMediaUrl', () => {
   it('returns null for falsy input', () => {
@@ -22,5 +22,61 @@ describe('resolveMediaUrl', () => {
     expect(
       resolveMediaUrl('media/logos/xyz.png', 'https://salonix-backend-production.up.railway.app/api/')
     ).toBe('https://salonix-backend-production.up.railway.app/media/logos/xyz.png');
+  });
+});
+
+describe('getWebOrigin', () => {
+  const originalEnv = process.env.WEB_ORIGIN;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.WEB_ORIGIN;
+    } else {
+      process.env.WEB_ORIGIN = originalEnv;
+    }
+  });
+
+  it('returns the WEB_ORIGIN env var when set, without a trailing slash', () => {
+    process.env.WEB_ORIGIN = 'https://custom.example.com/';
+    expect(getWebOrigin('https://irrelevant/api/')).toBe('https://custom.example.com');
+  });
+
+  it('returns localhost:5173 for a local dev API base', () => {
+    delete process.env.WEB_ORIGIN;
+    expect(getWebOrigin('http://0.0.0.0:8000/api/')).toBe('http://localhost:5173');
+    expect(getWebOrigin('http://192.168.0.203:8000/api/')).toBe('http://localhost:5173');
+  });
+
+  it('returns the staging web origin for the staging API base', () => {
+    delete process.env.WEB_ORIGIN;
+    expect(getWebOrigin('https://timelyonestaging.pythonanywhere.com/api/')).toBe(
+      'https://timelyone-staging.vercel.app'
+    );
+  });
+
+  it('returns the production web origin for the production API base', () => {
+    delete process.env.WEB_ORIGIN;
+    expect(getWebOrigin('https://salonix-backend-production.up.railway.app/api/')).toBe(
+      'https://timelyone.today'
+    );
+  });
+});
+
+describe('getRegistrationLink', () => {
+  afterEach(() => {
+    delete process.env.WEB_ORIGIN;
+  });
+
+  it('builds the join link from the web origin and tenant slug', () => {
+    expect(
+      getRegistrationLink('acme', 'https://salonix-backend-production.up.railway.app/api/')
+    ).toBe('https://timelyone.today/join/acme');
+  });
+
+  it('respects the WEB_ORIGIN env var override', () => {
+    process.env.WEB_ORIGIN = 'https://custom.example.com';
+    expect(getRegistrationLink('acme', 'https://irrelevant/api/')).toBe(
+      'https://custom.example.com/join/acme'
+    );
   });
 });

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -62,6 +62,31 @@ export const getResetUrl = () => {
   return "https://salonix-backend-production.up.railway.app/reset-password";
 };
 
+export function getWebOrigin(apiBase = getApiBaseUrl()) {
+  const envWebOrigin = getEnvVar("WEB_ORIGIN");
+  if (envWebOrigin) {
+    return envWebOrigin.endsWith("/") ? envWebOrigin.slice(0, -1) : envWebOrigin;
+  }
+
+  if (
+    apiBase.includes("localhost") ||
+    apiBase.includes("0.0.0.0") ||
+    apiBase.includes("192.168")
+  ) {
+    return "http://localhost:5173";
+  }
+
+  if (apiBase.includes("timelyonestaging.pythonanywhere.com")) {
+    return "https://timelyone-staging.vercel.app";
+  }
+
+  return "https://timelyone.today";
+}
+
+export function getRegistrationLink(slug, apiBase = getApiBaseUrl()) {
+  return `${getWebOrigin(apiBase)}/join/${slug}`;
+}
+
 export const API_BASE_URL = getApiBaseUrl();
 
 // O backend não tem storage em S3/CDN configurado — `logo_url`/`favicon_url`


### PR DESCRIPTION
## Resumo
- Adiciona os botões "Partilhar link" e "Gerar QR Code" na tela de Clientes, permitindo ao dono partilhar o link de auto-cadastro (`/join/:tenantSlug`) com clientes — recurso que já existia no FEW mas ficou de fora da última paridade (MOB-PARITY-01).
- "Partilhar link" usa o menu nativo de partilha do telemóvel (WhatsApp, SMS, etc.); "Gerar QR Code" abre um modal com o QR + link + botão copiar.
- Sem restrição de papel (owner/manager/collaborator) nos dois botões novos, igual ao comportamento já existente no FEW.
- Corrige também um problema de layout: a barra de ações não cabia mais na largura da tela com os 2 botões novos — passou a rolar horizontalmente.

## Test plan
- [x] 263/263 testes automatizados passando (Jest)
- [x] `tsc --noEmit` sem erros novos nos arquivos alterados
- [x] Validado visualmente no iOS (Expo Go) — QR Code, partilha e scroll horizontal da barra de ações funcionando
