### PR TITLE
feat: paridade de filtros de relatórios com o FEW

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "TimelyOne",
     "slug": "salonix-mobile",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/src/api/__tests__/reports.test.js
+++ b/src/api/__tests__/reports.test.js
@@ -41,6 +41,31 @@ describe('fetchTopServices', () => {
     });
     expect(result).toEqual({ top_services: [] });
   });
+
+  it('includes professional_id and service_id when provided', async () => {
+    client.get.mockResolvedValue({ data: { top_services: [] } });
+
+    await fetchTopServices({
+      from: '2026-06-09',
+      to: '2026-07-09',
+      limit: 10,
+      professionalId: '7',
+      serviceId: '3',
+      slug: 'acme',
+    });
+
+    expect(client.get).toHaveBeenCalledWith('reports/top-services/', {
+      headers: { 'X-Tenant-Slug': 'acme' },
+      params: {
+        tenant: 'acme',
+        from: '2026-06-09',
+        to: '2026-07-09',
+        limit: 10,
+        professional_id: '7',
+        service_id: '3',
+      },
+    });
+  });
 });
 
 describe('fetchRevenue', () => {
@@ -72,6 +97,17 @@ describe('fetchRetention', () => {
       params: { tenant: 'acme', from: '2026-06-09', to: '2026-07-09' },
     });
     expect(result).toEqual({ new_clients: { qty: 1 }, returning_clients: { qty: 2 } });
+  });
+
+  it('includes professional_id when provided', async () => {
+    client.get.mockResolvedValue({ data: { new_clients: { qty: 1 }, returning_clients: { qty: 2 } } });
+
+    await fetchRetention({ from: '2026-06-09', to: '2026-07-09', professionalId: '7', slug: 'acme' });
+
+    expect(client.get).toHaveBeenCalledWith('reports/retention/', {
+      headers: { 'X-Tenant-Slug': 'acme' },
+      params: { tenant: 'acme', from: '2026-06-09', to: '2026-07-09', professional_id: '7' },
+    });
   });
 });
 

--- a/src/api/reports.js
+++ b/src/api/reports.js
@@ -13,7 +13,7 @@ export async function fetchBasicReports({ from, to, slug } = {}) {
   return response.data;
 }
 
-export async function fetchTopServices({ from, to, limit, slug } = {}) {
+export async function fetchTopServices({ from, to, limit, professionalId, serviceId, slug } = {}) {
   const headers = {};
   const params = {};
   if (slug) {
@@ -23,6 +23,8 @@ export async function fetchTopServices({ from, to, limit, slug } = {}) {
   if (from) params.from = from;
   if (to) params.to = to;
   if (limit) params.limit = limit;
+  if (professionalId) params.professional_id = professionalId;
+  if (serviceId) params.service_id = serviceId;
   const response = await client.get('reports/top-services/', { headers, params });
   return response.data;
 }
@@ -41,7 +43,7 @@ export async function fetchRevenue({ from, to, interval, slug } = {}) {
   return response.data;
 }
 
-export async function fetchRetention({ from, to, slug } = {}) {
+export async function fetchRetention({ from, to, professionalId, slug } = {}) {
   const headers = {};
   const params = {};
   if (slug) {
@@ -50,6 +52,7 @@ export async function fetchRetention({ from, to, slug } = {}) {
   }
   if (from) params.from = from;
   if (to) params.to = to;
+  if (professionalId) params.professional_id = professionalId;
   const response = await client.get('reports/retention/', { headers, params });
   return response.data;
 }

--- a/src/screens/ReportsScreen.tsx
+++ b/src/screens/ReportsScreen.tsx
@@ -1,24 +1,39 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, StyleSheet, Alert, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
+import { Picker } from '@react-native-picker/picker';
 import { useTheme } from '../hooks/useTheme';
 import { useTenant } from '../hooks/useTenant';
 import { useAuth } from '../hooks/useAuth';
 import { isOwner } from '../utils/permissions';
 import { StatCard } from '../components/DashboardComponents';
+import { DatePickerInput } from '../components/DatePickerInput';
 import { fetchBasicReports, fetchTopServices, fetchRevenue, fetchRetention, exportBasicReportsCSV } from '../api/reports';
+import { fetchProfessionals } from '../api/professionals';
+import { fetchServices } from '../api/services';
 import { saveAndShareCSV } from '../utils/csvFileSharing';
 import { Button } from '../components/ui/Button';
+import { Modal } from '../components/ui/Modal';
 
 type TabKey = 'basic' | 'business' | 'insights';
+type IntervalKey = 'day' | 'week' | 'month';
+type SectionError = 'forbidden' | 'network' | null;
 
 const TABS: { key: TabKey; label: string }[] = [
   { key: 'basic', label: 'Básicos' },
   { key: 'business', label: 'Análise de Negócio' },
   { key: 'insights', label: 'Insights' },
 ];
+
+const INTERVAL_OPTIONS: { value: IntervalKey; label: string }[] = [
+  { value: 'day', label: 'Dia' },
+  { value: 'week', label: 'Semana' },
+  { value: 'month', label: 'Mês' },
+];
+
+const LIMIT_OPTIONS = [10, 25, 50, 100];
 
 function formatCurrency(value: number) {
   return new Intl.NumberFormat('pt-PT', { style: 'currency', currency: 'EUR' }).format(value || 0);
@@ -28,6 +43,37 @@ function formatShortDate(isoDate: string) {
   const date = new Date(isoDate);
   if (Number.isNaN(date.getTime())) return isoDate;
   return `${String(date.getDate()).padStart(2, '0')}/${String(date.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function formatDate(date: Date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+function getDefaultRange() {
+  const now = new Date();
+  const firstOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+  return {
+    from: formatDate(firstOfMonth),
+    to: formatDate(now),
+  };
+}
+
+function getErrorKind(error: any): SectionError {
+  return error?.response?.status === 403 ? 'forbidden' : 'network';
+}
+
+type Filters = {
+  from: string;
+  to: string;
+  professionalId: string;
+  serviceId: string;
+  interval: IntervalKey;
+  limit: number;
+};
+
+function getDefaultFilters(): Filters {
+  const { from, to } = getDefaultRange();
+  return { from, to, professionalId: '', serviceId: '', interval: 'week', limit: 10 };
 }
 
 export default function ReportsScreen() {
@@ -42,74 +88,150 @@ export default function ReportsScreen() {
     }
   }, [userInfo, navigation]);
 
-  const { from, to } = useMemo(() => {
-    const toDate = new Date();
-    const fromDate = new Date();
-    fromDate.setDate(fromDate.getDate() - 30);
-    return {
-      from: fromDate.toISOString().split('T')[0],
-      to: toDate.toISOString().split('T')[0],
-    };
-  }, []);
-
   const [activeTab, setActiveTab] = useState<TabKey>('basic');
   const [loading, setLoading] = useState(true);
   const [exporting, setExporting] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const [revenueView, setRevenueView] = useState<'chart' | 'table'>('chart');
+  const [professionalPickerOpen, setProfessionalPickerOpen] = useState(false);
+  const [servicePickerOpen, setServicePickerOpen] = useState(false);
+
+  const [applied, setApplied] = useState<Filters>(getDefaultFilters);
+  const [draft, setDraft] = useState<Filters>(applied);
+
+  const { from, to, professionalId, serviceId, interval, limit } = applied;
+
+  const [professionals, setProfessionals] = useState<any[]>([]);
+  const [services, setServices] = useState<any[]>([]);
 
   const [basic, setBasic] = useState<{ appointments_total: number; appointments_completed: number; revenue_total: number; avg_ticket: number } | null>(null);
   const [topServices, setTopServices] = useState<{ service_name: string; qty: number; revenue: number }[] | null>(null);
   const [revenueSeries, setRevenueSeries] = useState<{ period_start: string; revenue: number; appointment_count: number }[] | null>(null);
   const [retention, setRetention] = useState<{ new_clients: { qty: number; revenue: number }; returning_clients: { qty: number; revenue: number } } | null>(null);
 
+  const [businessLoading, setBusinessLoading] = useState(false);
+  const [businessError, setBusinessError] = useState<SectionError>(null);
+  const [insightsLoading, setInsightsLoading] = useState(false);
+  const [insightsError, setInsightsError] = useState<SectionError>(null);
+
+  const lastBusinessKeyRef = useRef<string | null>(null);
+  const lastInsightsKeyRef = useRef<string | null>(null);
+
+  // Load professionals/services once for the filter pickers (business/insights tabs).
+  useEffect(() => {
+    let active = true;
+    fetchProfessionals({ slug, limit: 100 } as any).then((data: any) => {
+      if (!active) return;
+      setProfessionals(Array.isArray(data) ? data : data.results || []);
+    }).catch(() => {});
+    fetchServices({ slug } as any).then((data: any) => {
+      if (!active) return;
+      setServices(Array.isArray(data) ? data : data.results || []);
+    }).catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, [slug]);
+
   useEffect(() => {
     let active = true;
     fetchBasicReports({ from, to, slug }).then((data: any) => {
       if (!active) return;
       setBasic(data.overview);
-      setLoading(false);
     }).catch(() => {
       if (!active) return;
-      setLoading(false);
       Alert.alert('Erro', 'Não foi possível carregar os dados desta aba.');
+    }).finally(() => {
+      if (!active) return;
+      setLoading(false);
     });
     return () => {
       active = false;
     };
   }, [from, to, slug]);
 
-  useEffect(() => {
-    if (activeTab !== 'business' || topServices !== null) return;
-    let active = true;
-    Promise.all([
-      fetchTopServices({ from, to, limit: 10, slug }),
-      fetchRevenue({ from, to, interval: 'week', slug }),
-    ]).then(([topServicesData, revenueData]: any[]) => {
-      if (!active) return;
-      setTopServices(topServicesData.top_services || []);
-      setRevenueSeries(revenueData.revenue?.series || []);
-    }).catch(() => {
-      if (!active) return;
-      Alert.alert('Erro', 'Não foi possível carregar os dados desta aba.');
-    });
-    return () => {
-      active = false;
-    };
-  }, [activeTab, from, to, slug, topServices]);
+  const businessKey = useMemo(
+    () => JSON.stringify({ from, to, professionalId, serviceId, interval, limit, slug }),
+    [from, to, professionalId, serviceId, interval, limit, slug]
+  );
+
+  const fetchBusinessData = async () => {
+    setBusinessLoading(true);
+    setBusinessError(null);
+    try {
+      const [topServicesData, revenueData] = await Promise.all([
+        fetchTopServices({
+          from,
+          to,
+          limit,
+          professionalId: professionalId || undefined,
+          serviceId: serviceId || undefined,
+          slug,
+        }),
+        fetchRevenue({ from, to, interval, slug }),
+      ]);
+      setTopServices(Array.isArray(topServicesData) ? topServicesData : topServicesData?.top_services || []);
+      setRevenueSeries(revenueData?.series || []);
+      lastBusinessKeyRef.current = businessKey;
+    } catch (error: any) {
+      const kind = getErrorKind(error);
+      setBusinessError(kind);
+      if (kind !== 'forbidden') {
+        Alert.alert('Erro', 'Não foi possível carregar os dados desta aba.');
+      }
+    } finally {
+      setBusinessLoading(false);
+    }
+  };
 
   useEffect(() => {
-    if (activeTab !== 'insights' || retention !== null) return;
-    let active = true;
-    fetchRetention({ from, to, slug }).then((data: any) => {
-      if (!active) return;
+    if (activeTab !== 'business') return;
+    if (lastBusinessKeyRef.current === businessKey) return;
+    fetchBusinessData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab, businessKey]);
+
+  const insightsKey = useMemo(
+    () => JSON.stringify({ from, to, professionalId, slug }),
+    [from, to, professionalId, slug]
+  );
+
+  const fetchInsightsData = async () => {
+    setInsightsLoading(true);
+    setInsightsError(null);
+    try {
+      const data = await fetchRetention({ from, to, professionalId: professionalId || undefined, slug });
       setRetention(data);
-    }).catch(() => {
-      if (!active) return;
-      Alert.alert('Erro', 'Não foi possível carregar os dados desta aba.');
-    });
-    return () => {
-      active = false;
-    };
-  }, [activeTab, from, to, slug, retention]);
+      lastInsightsKeyRef.current = insightsKey;
+    } catch (error: any) {
+      const kind = getErrorKind(error);
+      setInsightsError(kind);
+      if (kind !== 'forbidden') {
+        Alert.alert('Erro', 'Não foi possível carregar os dados desta aba.');
+      }
+    } finally {
+      setInsightsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (activeTab !== 'insights') return;
+    if (lastInsightsKeyRef.current === insightsKey) return;
+    fetchInsightsData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab, insightsKey]);
+
+  const handleApplyFilters = () => {
+    setApplied(draft);
+    setFiltersOpen(false);
+  };
+
+  const handleClearFilters = () => {
+    const defaults = getDefaultFilters();
+    setDraft(defaults);
+    setApplied(defaults);
+    setFiltersOpen(false);
+  };
 
   const handleExportCSV = async () => {
     setExporting(true);
@@ -147,6 +269,15 @@ export default function ReportsScreen() {
     ? `${((retention.returning_clients.qty / totalRetention) * 100).toFixed(1)}%`
     : '0.0%';
 
+  const intervalLabel = INTERVAL_OPTIONS.find((option) => option.value === interval)?.label || 'período';
+
+  const draftProfessionalLabel = draft.professionalId
+    ? professionals.find((prof: any) => String(prof.id) === draft.professionalId)?.name || 'Todos'
+    : 'Todos';
+  const draftServiceLabel = draft.serviceId
+    ? services.find((service: any) => String(service.id) === draft.serviceId)?.name || 'Todos'
+    : 'Todos';
+
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
       <View style={styles.header}>
@@ -154,7 +285,9 @@ export default function ReportsScreen() {
           <Ionicons name="arrow-back" size={22} color={colors.textPrimary} />
         </TouchableOpacity>
         <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>Relatórios</Text>
-        <View style={{ width: 38 }} />
+        <TouchableOpacity onPress={() => setFiltersOpen((prev) => !prev)} style={styles.backBtn} testID="toggle-filters">
+          <Ionicons name="options-outline" size={22} color={colors.brandPrimary} />
+        </TouchableOpacity>
       </View>
 
       <View style={styles.tabRow}>
@@ -175,6 +308,112 @@ export default function ReportsScreen() {
       </View>
 
       <ScrollView contentContainerStyle={{ padding: 16, paddingBottom: 40 }}>
+        {filtersOpen && (
+          <View style={[styles.filtersBox, { borderColor: colors.border, backgroundColor: colors.surface }]}>
+            <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>Filtros</Text>
+
+            <DatePickerInput
+              label="Data inicial"
+              placeholder="Selecione uma data"
+              value={draft.from}
+              onDateChange={(date) => setDraft((prev) => ({ ...prev, from: date }))}
+            />
+            <DatePickerInput
+              label="Data final"
+              placeholder="Selecione uma data"
+              value={draft.to}
+              onDateChange={(date) => setDraft((prev) => ({ ...prev, to: date }))}
+            />
+
+            {(activeTab === 'business' || activeTab === 'insights') && (
+              <View style={styles.inputGroup}>
+                <Text style={[styles.filterLabel, { color: colors.textPrimary }]}>Profissional</Text>
+                <TouchableOpacity
+                  testID="reports-professional-picker-trigger"
+                  onPress={() => setProfessionalPickerOpen(true)}
+                  style={[styles.pickerTrigger, { borderColor: colors.border, backgroundColor: colors.background }]}
+                >
+                  <Text style={{ color: colors.textPrimary, fontSize: 14 }}>{draftProfessionalLabel}</Text>
+                  <Ionicons name="chevron-down" size={18} color={colors.textSecondary} />
+                </TouchableOpacity>
+              </View>
+            )}
+
+            {activeTab === 'business' && (
+              <View style={styles.inputGroup}>
+                <Text style={[styles.filterLabel, { color: colors.textPrimary }]}>Serviço</Text>
+                <TouchableOpacity
+                  testID="reports-service-picker-trigger"
+                  onPress={() => setServicePickerOpen(true)}
+                  style={[styles.pickerTrigger, { borderColor: colors.border, backgroundColor: colors.background }]}
+                >
+                  <Text style={{ color: colors.textPrimary, fontSize: 14 }}>{draftServiceLabel}</Text>
+                  <Ionicons name="chevron-down" size={18} color={colors.textSecondary} />
+                </TouchableOpacity>
+              </View>
+            )}
+
+            {activeTab === 'business' && (
+              <>
+                <View style={styles.inputGroup}>
+                  <Text style={[styles.filterLabel, { color: colors.textPrimary }]}>Intervalo de Tempo</Text>
+                  <View style={{ flexDirection: 'row', gap: 8 }}>
+                    {INTERVAL_OPTIONS.map((option) => {
+                      const active = draft.interval === option.value;
+                      return (
+                        <TouchableOpacity
+                          key={option.value}
+                          onPress={() => setDraft((prev) => ({ ...prev, interval: option.value }))}
+                          style={[
+                            styles.periodOption,
+                            { borderColor: active ? colors.brandPrimary : colors.border, backgroundColor: active ? colors.brandPrimary : 'transparent' },
+                          ]}
+                        >
+                          <Text style={{ color: active ? '#fff' : colors.textPrimary, fontWeight: '600', fontSize: 13 }}>
+                            {option.label}
+                          </Text>
+                        </TouchableOpacity>
+                      );
+                    })}
+                  </View>
+                </View>
+
+                <View style={styles.inputGroup}>
+                  <Text style={[styles.filterLabel, { color: colors.textPrimary }]}>Itens por Página</Text>
+                  <View style={{ flexDirection: 'row', gap: 8 }}>
+                    {LIMIT_OPTIONS.map((option) => {
+                      const active = draft.limit === option;
+                      return (
+                        <TouchableOpacity
+                          key={option}
+                          onPress={() => setDraft((prev) => ({ ...prev, limit: option }))}
+                          style={[
+                            styles.periodOption,
+                            { borderColor: active ? colors.brandPrimary : colors.border, backgroundColor: active ? colors.brandPrimary : 'transparent' },
+                          ]}
+                        >
+                          <Text style={{ color: active ? '#fff' : colors.textPrimary, fontWeight: '600', fontSize: 13 }}>
+                            {option}
+                          </Text>
+                        </TouchableOpacity>
+                      );
+                    })}
+                  </View>
+                </View>
+              </>
+            )}
+
+            <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 4 }}>
+              <TouchableOpacity onPress={handleClearFilters}>
+                <Text style={{ color: colors.textSecondary, fontSize: 13, fontWeight: '600' }}>Limpar</Text>
+              </TouchableOpacity>
+              <TouchableOpacity onPress={handleApplyFilters}>
+                <Text style={{ color: colors.brandPrimary, fontSize: 13, fontWeight: '600' }}>Aplicar filtros</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        )}
+
         {activeTab === 'basic' && basic && (
           <>
             <StatCard label="Agendamentos Totais" value={basic.appointments_total} />
@@ -190,72 +429,252 @@ export default function ReportsScreen() {
 
         {activeTab === 'business' && (
           <>
-            <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>Top Serviços</Text>
-            {topServices === null ? (
+            {businessLoading && (
               <ActivityIndicator size="small" color={colors.brandPrimary} style={{ marginBottom: 16 }} />
-            ) : (
-              topServices.map((service) => (
-                <View key={service.service_name} style={[styles.serviceRow, { borderColor: colors.border, backgroundColor: colors.surface }]}>
-                  <Text style={{ color: colors.textPrimary, fontWeight: '600' }}>{service.service_name}</Text>
-                  <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 4 }}>
-                    <Text style={{ color: colors.textSecondary, fontSize: 13 }}>{service.qty} agendamentos</Text>
-                    <Text style={{ color: colors.textSecondary, fontSize: 13 }}>{formatCurrency(service.revenue)}</Text>
-                  </View>
-                </View>
-              ))
             )}
 
-            <Text style={[styles.sectionTitle, { color: colors.textPrimary, marginTop: 16 }]}>Receita por semana</Text>
-            {revenueSeries === null ? (
-              <ActivityIndicator size="small" color={colors.brandPrimary} />
-            ) : (
-              <View style={styles.barChartRow}>
-                {revenueSeries.map((item) => (
-                  <View key={item.period_start} style={styles.barColumn}>
-                    <Text style={{ color: colors.textSecondary, fontSize: 10, marginBottom: 4 }}>
-                      {formatCurrency(item.revenue)}
-                    </Text>
-                    <View
-                      style={[
-                        styles.bar,
-                        {
-                          height: Math.max(4, (item.revenue / maxRevenue) * 100),
-                          backgroundColor: colors.brandPrimary,
-                        },
-                      ]}
-                    />
-                    <Text style={{ color: colors.textSecondary, fontSize: 10, marginTop: 4 }}>
-                      {formatShortDate(item.period_start)}
-                    </Text>
-                  </View>
-                ))}
+            {!businessLoading && businessError === 'forbidden' && (
+              <View style={[styles.banner, { backgroundColor: colors.warningBackground, borderColor: colors.border }]}>
+                <Text style={{ color: colors.textPrimary, fontSize: 13 }}>
+                  O seu plano atual não inclui a Análise de Negócio.
+                </Text>
+                <TouchableOpacity onPress={() => navigation.navigate('CreditsPlan' as never)} style={{ marginTop: 8 }}>
+                  <Text style={{ color: colors.brandPrimary, fontWeight: '600', fontSize: 13 }}>Ver planos</Text>
+                </TouchableOpacity>
               </View>
+            )}
+
+            {!businessLoading && businessError === 'network' && (
+              <View style={[styles.banner, { backgroundColor: colors.errorBackground, borderColor: colors.border }]}>
+                <Text style={{ color: colors.textPrimary, fontSize: 13 }}>
+                  Não foi possível carregar os dados desta aba.
+                </Text>
+                <TouchableOpacity onPress={fetchBusinessData} style={{ marginTop: 8 }}>
+                  <Text style={{ color: colors.brandPrimary, fontWeight: '600', fontSize: 13 }}>Tentar novamente</Text>
+                </TouchableOpacity>
+              </View>
+            )}
+
+            {!businessLoading && !businessError && (
+              <>
+                <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>Top Serviços</Text>
+                {topServices && topServices.length === 0 ? (
+                  <Text style={{ color: colors.textSecondary, fontSize: 13, marginBottom: 16 }}>
+                    Nenhum dado no período selecionado.
+                  </Text>
+                ) : (
+                  topServices?.map((service) => (
+                    <View key={service.service_name} style={[styles.serviceRow, { borderColor: colors.border, backgroundColor: colors.surface }]}>
+                      <Text style={{ color: colors.textPrimary, fontWeight: '600' }}>{service.service_name}</Text>
+                      <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 4 }}>
+                        <Text style={{ color: colors.textSecondary, fontSize: 13 }}>{service.qty} agendamentos</Text>
+                        <Text style={{ color: colors.textSecondary, fontSize: 13 }}>{formatCurrency(service.revenue)}</Text>
+                      </View>
+                    </View>
+                  ))
+                )}
+
+                <Text style={[styles.sectionTitle, { color: colors.textPrimary, marginTop: 16 }]}>Receita por {intervalLabel}</Text>
+                {revenueSeries && revenueSeries.length === 0 ? (
+                  <Text style={{ color: colors.textSecondary, fontSize: 13 }}>
+                    Nenhum dado no período selecionado.
+                  </Text>
+                ) : (
+                  <>
+                    <View style={{ flexDirection: 'row', gap: 8, marginBottom: 12 }}>
+                      <TouchableOpacity
+                        testID="revenue-view-chart"
+                        onPress={() => setRevenueView('chart')}
+                        style={[
+                          styles.periodOption,
+                          {
+                            borderColor: revenueView === 'chart' ? colors.brandPrimary : colors.border,
+                            backgroundColor: revenueView === 'chart' ? colors.brandPrimary : 'transparent',
+                          },
+                        ]}
+                      >
+                        <Text style={{ color: revenueView === 'chart' ? '#fff' : colors.textPrimary, fontWeight: '600', fontSize: 13 }}>
+                          Gráfico
+                        </Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity
+                        testID="revenue-view-table"
+                        onPress={() => setRevenueView('table')}
+                        style={[
+                          styles.periodOption,
+                          {
+                            borderColor: revenueView === 'table' ? colors.brandPrimary : colors.border,
+                            backgroundColor: revenueView === 'table' ? colors.brandPrimary : 'transparent',
+                          },
+                        ]}
+                      >
+                        <Text style={{ color: revenueView === 'table' ? '#fff' : colors.textPrimary, fontWeight: '600', fontSize: 13 }}>
+                          Tabela
+                        </Text>
+                      </TouchableOpacity>
+                    </View>
+
+                    {revenueView === 'chart' ? (
+                      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                        <View style={styles.barChartRow}>
+                          {revenueSeries?.map((item) => (
+                            <View key={item.period_start} style={styles.barColumn}>
+                              <Text style={{ color: colors.textSecondary, fontSize: 10, marginBottom: 4 }}>
+                                {formatCurrency(item.revenue)}
+                              </Text>
+                              <View
+                                style={[
+                                  styles.bar,
+                                  {
+                                    height: Math.max(4, (item.revenue / maxRevenue) * 100),
+                                    backgroundColor: colors.brandPrimary,
+                                  },
+                                ]}
+                              />
+                              <Text style={{ color: colors.textSecondary, fontSize: 10, marginTop: 4 }}>
+                                {formatShortDate(item.period_start)}
+                              </Text>
+                            </View>
+                          ))}
+                        </View>
+                      </ScrollView>
+                    ) : (
+                      <View style={[styles.table, { borderColor: colors.border, backgroundColor: colors.surface }]} testID="revenue-table">
+                        <View style={[styles.tableRow, styles.tableHeaderRow, { borderColor: colors.border }]}>
+                          <Text style={[styles.tableCell, styles.tableHeaderCell, { color: colors.textSecondary, flex: 1.2 }]}>Período</Text>
+                          <Text style={[styles.tableCell, styles.tableHeaderCell, { color: colors.textSecondary, flex: 1 }]}>Receita</Text>
+                          <Text style={[styles.tableCell, styles.tableHeaderCell, { color: colors.textSecondary, flex: 1, textAlign: 'right' }]}>
+                            Agend.
+                          </Text>
+                        </View>
+                        {revenueSeries?.map((item) => (
+                          <View key={item.period_start} style={[styles.tableRow, { borderColor: colors.border }]}>
+                            <Text style={[styles.tableCell, { color: colors.textPrimary, flex: 1.2 }]}>
+                              {formatShortDate(item.period_start)}
+                            </Text>
+                            <Text style={[styles.tableCell, { color: colors.textPrimary, flex: 1 }]}>
+                              {formatCurrency(item.revenue)}
+                            </Text>
+                            <Text style={[styles.tableCell, { color: colors.textPrimary, flex: 1, textAlign: 'right' }]}>
+                              {item.appointment_count}
+                            </Text>
+                          </View>
+                        ))}
+                      </View>
+                    )}
+                  </>
+                )}
+              </>
             )}
           </>
         )}
 
         {activeTab === 'insights' && (
           <>
-            <StatCard label="Taxa de Retenção" value={retentionRate} isPrimary />
-            {retention === null ? (
-              <ActivityIndicator size="small" color={colors.brandPrimary} />
-            ) : (
-              <View style={{ flexDirection: 'row', gap: 12 }}>
-                <View style={[styles.retentionCard, { borderColor: colors.border, backgroundColor: colors.surface }]}>
-                  <Text style={{ color: colors.textSecondary, fontSize: 12 }}>Novos</Text>
-                  <Text style={{ color: colors.textPrimary, fontSize: 18, fontWeight: '700' }}>{retention.new_clients.qty}</Text>
-                  <Text style={{ color: colors.textSecondary, fontSize: 12 }}>{formatCurrency(retention.new_clients.revenue)}</Text>
-                </View>
-                <View style={[styles.retentionCard, { borderColor: colors.border, backgroundColor: colors.surface }]}>
-                  <Text style={{ color: colors.textSecondary, fontSize: 12 }}>Recorrentes</Text>
-                  <Text style={{ color: colors.textPrimary, fontSize: 18, fontWeight: '700' }}>{retention.returning_clients.qty}</Text>
-                  <Text style={{ color: colors.textSecondary, fontSize: 12 }}>{formatCurrency(retention.returning_clients.revenue)}</Text>
-                </View>
+            {insightsLoading && (
+              <ActivityIndicator size="small" color={colors.brandPrimary} style={{ marginBottom: 16 }} />
+            )}
+
+            {!insightsLoading && insightsError === 'forbidden' && (
+              <View style={[styles.banner, { backgroundColor: colors.warningBackground, borderColor: colors.border }]}>
+                <Text style={{ color: colors.textPrimary, fontSize: 13 }}>
+                  O seu plano atual não inclui os Insights.
+                </Text>
+                <TouchableOpacity onPress={() => navigation.navigate('CreditsPlan' as never)} style={{ marginTop: 8 }}>
+                  <Text style={{ color: colors.brandPrimary, fontWeight: '600', fontSize: 13 }}>Ver planos</Text>
+                </TouchableOpacity>
               </View>
+            )}
+
+            {!insightsLoading && insightsError === 'network' && (
+              <View style={[styles.banner, { backgroundColor: colors.errorBackground, borderColor: colors.border }]}>
+                <Text style={{ color: colors.textPrimary, fontSize: 13 }}>
+                  Não foi possível carregar os dados desta aba.
+                </Text>
+                <TouchableOpacity onPress={fetchInsightsData} style={{ marginTop: 8 }}>
+                  <Text style={{ color: colors.brandPrimary, fontWeight: '600', fontSize: 13 }}>Tentar novamente</Text>
+                </TouchableOpacity>
+              </View>
+            )}
+
+            {!insightsLoading && !insightsError && (
+              <>
+                <StatCard label="Taxa de Retenção" value={retentionRate} isPrimary />
+                {retention && totalRetention === 0 ? (
+                  <Text style={{ color: colors.textSecondary, fontSize: 13 }}>
+                    Nenhum dado no período selecionado.
+                  </Text>
+                ) : retention ? (
+                  <View style={{ flexDirection: 'row', gap: 12 }}>
+                    <View style={[styles.retentionCard, { borderColor: colors.border, backgroundColor: colors.surface }]}>
+                      <Text style={{ color: colors.textSecondary, fontSize: 12 }}>Novos</Text>
+                      <Text style={{ color: colors.textPrimary, fontSize: 18, fontWeight: '700' }}>{retention.new_clients.qty}</Text>
+                      <Text style={{ color: colors.textSecondary, fontSize: 12 }}>{formatCurrency(retention.new_clients.revenue)}</Text>
+                    </View>
+                    <View style={[styles.retentionCard, { borderColor: colors.border, backgroundColor: colors.surface }]}>
+                      <Text style={{ color: colors.textSecondary, fontSize: 12 }}>Recorrentes</Text>
+                      <Text style={{ color: colors.textPrimary, fontSize: 18, fontWeight: '700' }}>{retention.returning_clients.qty}</Text>
+                      <Text style={{ color: colors.textSecondary, fontSize: 12 }}>{formatCurrency(retention.returning_clients.revenue)}</Text>
+                    </View>
+                  </View>
+                ) : null}
+              </>
             )}
           </>
         )}
       </ScrollView>
+
+      <Modal
+        visible={professionalPickerOpen}
+        onClose={() => setProfessionalPickerOpen(false)}
+        title="Profissional"
+        footer={
+          <Button onPress={() => setProfessionalPickerOpen(false)} style={{ flex: 1 }}>
+            Concluir
+          </Button>
+        }
+      >
+        <Picker
+          key={`professional-picker-${professionals.length}`}
+          testID="reports-professional-picker"
+          selectedValue={draft.professionalId}
+          onValueChange={(value) => setDraft((prev) => ({ ...prev, professionalId: String(value) }))}
+          style={{ color: colors.textPrimary }}
+          itemStyle={{ color: colors.textPrimary }}
+          dropdownIconColor={colors.textPrimary}
+        >
+          <Picker.Item label="Todos" value="" color={colors.textPrimary} />
+          {professionals.map((prof: any) => (
+            <Picker.Item key={prof.id} label={prof.name} value={String(prof.id)} color={colors.textPrimary} />
+          ))}
+        </Picker>
+      </Modal>
+
+      <Modal
+        visible={servicePickerOpen}
+        onClose={() => setServicePickerOpen(false)}
+        title="Serviço"
+        footer={
+          <Button onPress={() => setServicePickerOpen(false)} style={{ flex: 1 }}>
+            Concluir
+          </Button>
+        }
+      >
+        <Picker
+          key={`service-picker-${services.length}`}
+          testID="reports-service-picker"
+          selectedValue={draft.serviceId}
+          onValueChange={(value) => setDraft((prev) => ({ ...prev, serviceId: String(value) }))}
+          style={{ color: colors.textPrimary }}
+          itemStyle={{ color: colors.textPrimary }}
+          dropdownIconColor={colors.textPrimary}
+        >
+          <Picker.Item label="Todos" value="" color={colors.textPrimary} />
+          {services.map((service: any) => (
+            <Picker.Item key={service.id} label={service.name} value={String(service.id)} color={colors.textPrimary} />
+          ))}
+        </Picker>
+      </Modal>
     </SafeAreaView>
   );
 }
@@ -300,15 +719,16 @@ const styles = StyleSheet.create({
   barChartRow: {
     flexDirection: 'row',
     alignItems: 'flex-end',
-    justifyContent: 'space-between',
+    gap: 24,
     height: 160,
+    paddingHorizontal: 4,
   },
   barColumn: {
     alignItems: 'center',
-    flex: 1,
+    width: 56,
   },
   bar: {
-    width: 20,
+    width: 28,
     borderRadius: 4,
   },
   retentionCard: {
@@ -316,5 +736,67 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: 8,
     padding: 12,
+  },
+  filtersBox: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+  },
+  inputGroup: {
+    marginBottom: 12,
+  },
+  filterLabel: {
+    fontSize: 14,
+    fontWeight: '500',
+    marginBottom: 6,
+  },
+  pickerContainer: {
+    borderWidth: 1,
+    borderRadius: 8,
+  },
+  pickerTrigger: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+  },
+  table: {
+    borderWidth: 1,
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+  tableRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderTopWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  tableHeaderRow: {
+    borderTopWidth: 0,
+  },
+  tableCell: {
+    fontSize: 13,
+  },
+  tableHeaderCell: {
+    fontSize: 11,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+  },
+  periodOption: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  banner: {
+    borderWidth: 1,
+    borderRadius: 10,
+    padding: 12,
+    marginBottom: 16,
   },
 });

--- a/src/screens/__tests__/ReportsScreen.test.tsx
+++ b/src/screens/__tests__/ReportsScreen.test.tsx
@@ -1,7 +1,20 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
 import { Alert } from 'react-native';
 import ReportsScreen from '../ReportsScreen';
+
+// Nota: `@react-native-picker/picker` não responde a `fireEvent(el, 'valueChange', ...)`
+// neste ambiente de testes — o host component subjacente expõe um prop `onChange` que
+// espera `{ nativeEvent: { newValue, newIndex } }`. A forma confirmada e fiável de
+// simular a seleção é invocar `onChange` diretamente, dentro de `act()` (ver
+// SlotBulkGenerateModal.test.tsx para o mesmo padrão).
+async function selectPickerValue(getByTestId: any, testId: string, value: string, index = 0) {
+  await act(async () => {
+    getByTestId(testId).props.onChange({
+      nativeEvent: { newValue: value, newIndex: index },
+    });
+  });
+}
 
 jest.mock('../../hooks/useTheme', () => ({
   useTheme: () => ({
@@ -16,13 +29,16 @@ jest.mock('../../hooks/useTheme', () => ({
       surfaceVariant: '#eee',
       success: '#22c55e',
       error: '#ef4444',
+      warningBackground: '#fef3c7',
+      errorBackground: '#fee2e2',
     },
   }),
 }));
 
 const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({ goBack: mockGoBack }),
+  useNavigation: () => ({ goBack: mockGoBack, navigate: mockNavigate }),
 }));
 
 let mockUseAuthReturn: any = { userInfo: { id: 1, role: 'owner' } };
@@ -47,6 +63,16 @@ jest.mock('../../api/reports', () => ({
   exportBasicReportsCSV: (...args: any[]) => mockExportBasicReportsCSV(...args),
 }));
 
+const mockFetchProfessionals = jest.fn();
+jest.mock('../../api/professionals', () => ({
+  fetchProfessionals: (...args: any[]) => mockFetchProfessionals(...args),
+}));
+
+const mockFetchServices = jest.fn();
+jest.mock('../../api/services', () => ({
+  fetchServices: (...args: any[]) => mockFetchServices(...args),
+}));
+
 const mockSaveAndShareCSV = jest.fn();
 jest.mock('../../utils/csvFileSharing', () => ({
   saveAndShareCSV: (...args: any[]) => mockSaveAndShareCSV(...args),
@@ -62,12 +88,10 @@ const TOP_SERVICES = {
   ],
 };
 const REVENUE = {
-  revenue: {
-    series: [
-      { period_start: '2026-06-15', revenue: 300, appointment_count: 10 },
-      { period_start: '2026-06-22', revenue: 500, appointment_count: 15 },
-    ],
-  },
+  series: [
+    { period_start: '2026-06-15', revenue: 300, appointment_count: 10 },
+    { period_start: '2026-06-22', revenue: 500, appointment_count: 15 },
+  ],
 };
 const RETENTION = {
   new_clients: { qty: 4, revenue: 120 },
@@ -78,10 +102,13 @@ describe('ReportsScreen', () => {
   beforeEach(() => {
     mockUseAuthReturn = { userInfo: { id: 1, role: 'owner' } };
     mockGoBack.mockClear();
+    mockNavigate.mockClear();
     mockFetchBasicReports.mockResolvedValue(BASIC);
     mockFetchTopServices.mockResolvedValue(TOP_SERVICES);
     mockFetchRevenue.mockResolvedValue(REVENUE);
     mockFetchRetention.mockResolvedValue(RETENTION);
+    mockFetchProfessionals.mockResolvedValue({ results: [{ id: 1, name: 'Ana' }] });
+    mockFetchServices.mockResolvedValue({ results: [{ id: 9, name: 'Corte' }] });
   });
   afterEach(() => jest.clearAllMocks());
 
@@ -112,16 +139,18 @@ describe('ReportsScreen', () => {
     expect(mockFetchRetention).not.toHaveBeenCalled();
   });
 
-  it('sends from/to 30 days apart and no interval on the Básicos fetch', async () => {
-    await render(<ReportsScreen />);
+  it('defaults the date range to the current month (1st of month through today)', async () => {
+    render(<ReportsScreen />);
 
     await waitFor(() => expect(mockFetchBasicReports).toHaveBeenCalled());
     const call = mockFetchBasicReports.mock.calls[0][0];
     expect(call.slug).toBe('acme');
-    const from = new Date(call.from);
-    const to = new Date(call.to);
-    const diffDays = Math.round((to.getTime() - from.getTime()) / (1000 * 60 * 60 * 24));
-    expect(diffDays).toBe(30);
+
+    const now = new Date();
+    const expectedFrom = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`;
+    const expectedTo = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+    expect(call.from).toBe(expectedFrom);
+    expect(call.to).toBe(expectedTo);
   });
 
   it('fetches Top Serviços e Receita only when the Análise de Negócio tab is opened, and only once', async () => {
@@ -138,7 +167,7 @@ describe('ReportsScreen', () => {
     expect(mockFetchRevenue).toHaveBeenCalledWith(
       expect.objectContaining({ interval: 'week', slug: 'acme' })
     );
-    expect(getByText('Corte')).toBeTruthy();
+    await waitFor(() => expect(getByText('Corte')).toBeTruthy());
     expect(getByText('Manicure')).toBeTruthy();
 
     await fireEvent.press(getByText('Básicos'));
@@ -146,6 +175,27 @@ describe('ReportsScreen', () => {
 
     expect(mockFetchTopServices).toHaveBeenCalledTimes(1);
     expect(mockFetchRevenue).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not send professional_id/service_id when the "Todos" filter option is selected (default state)', async () => {
+    const { getByText } = await render(<ReportsScreen />);
+    await waitFor(() => expect(mockFetchBasicReports).toHaveBeenCalled());
+
+    await fireEvent.press(getByText('Análise de Negócio'));
+    await waitFor(() => expect(mockFetchTopServices).toHaveBeenCalled());
+
+    const topServicesCall = mockFetchTopServices.mock.calls[0][0];
+    expect(topServicesCall.professionalId).toBeUndefined();
+    expect(topServicesCall.serviceId).toBeUndefined();
+    expect(topServicesCall).not.toHaveProperty('professional_id');
+    expect(topServicesCall).not.toHaveProperty('service_id');
+
+    await fireEvent.press(getByText('Insights'));
+    await waitFor(() => expect(mockFetchRetention).toHaveBeenCalled());
+
+    const retentionCall = mockFetchRetention.mock.calls[0][0];
+    expect(retentionCall.professionalId).toBeUndefined();
+    expect(retentionCall).not.toHaveProperty('professional_id');
   });
 
   it('fetches Retenção only when the Insights tab is opened, and shows the calculated rate', async () => {
@@ -156,10 +206,10 @@ describe('ReportsScreen', () => {
 
     await waitFor(() => expect(mockFetchRetention).toHaveBeenCalled());
     // 6 returning / (4 new + 6 returning) = 60.0%
-    expect(getByText('60.0%')).toBeTruthy();
+    await waitFor(() => expect(getByText('60.0%')).toBeTruthy());
   });
 
-  it('shows an alert and does not crash when a tab fetch fails', async () => {
+  it('shows a network error banner with a retry action when a tab fetch fails with a non-403 error', async () => {
     mockFetchTopServices.mockRejectedValue({ response: { status: 500, data: {} } });
     const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
 
@@ -171,8 +221,116 @@ describe('ReportsScreen', () => {
     await waitFor(() => {
       expect(alertSpy).toHaveBeenCalledWith('Erro', 'Não foi possível carregar os dados desta aba.');
     });
+    expect(getByText('Não foi possível carregar os dados desta aba.')).toBeTruthy();
+    expect(getByText('Tentar novamente')).toBeTruthy();
 
     alertSpy.mockRestore();
+  });
+
+  it('shows a plan-gated (forbidden) message instead of a generic alert on a 403', async () => {
+    mockFetchTopServices.mockRejectedValue({ response: { status: 403, data: {} } });
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+
+    const { getByText } = await render(<ReportsScreen />);
+    await waitFor(() => expect(mockFetchBasicReports).toHaveBeenCalled());
+
+    await fireEvent.press(getByText('Análise de Negócio'));
+
+    await waitFor(() => {
+      expect(getByText('O seu plano atual não inclui a Análise de Negócio.')).toBeTruthy();
+    });
+    expect(alertSpy).not.toHaveBeenCalled();
+    expect(getByText('Ver planos')).toBeTruthy();
+
+    alertSpy.mockRestore();
+  });
+
+  it('shows an empty-state message when a tab returns no data for the period', async () => {
+    mockFetchTopServices.mockResolvedValue({ top_services: [] });
+    mockFetchRevenue.mockResolvedValue({ revenue: { series: [] } });
+
+    const { getByText, getAllByText } = await render(<ReportsScreen />);
+    await waitFor(() => expect(mockFetchBasicReports).toHaveBeenCalled());
+
+    await fireEvent.press(getByText('Análise de Negócio'));
+
+    await waitFor(() => {
+      expect(getAllByText('Nenhum dado no período selecionado.').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('re-fetches the Análise de Negócio tab when the interval filter changes and is applied', async () => {
+    const { getByText, getByTestId } = await render(<ReportsScreen />);
+    await waitFor(() => expect(mockFetchBasicReports).toHaveBeenCalled());
+
+    await fireEvent.press(getByText('Análise de Negócio'));
+    await waitFor(() => expect(mockFetchRevenue).toHaveBeenCalledTimes(1));
+    expect(mockFetchRevenue).toHaveBeenCalledWith(expect.objectContaining({ interval: 'week' }));
+
+    await fireEvent.press(getByTestId('toggle-filters'));
+    await fireEvent.press(getByText('Mês'));
+    await fireEvent.press(getByText('Aplicar filtros'));
+
+    await waitFor(() => expect(mockFetchRevenue).toHaveBeenCalledTimes(2));
+    expect(mockFetchRevenue).toHaveBeenLastCalledWith(expect.objectContaining({ interval: 'month' }));
+  });
+
+  it('toggles the revenue chart to a table view with formatted period/revenue/appointments rows', async () => {
+    const { getByText, getByTestId, queryByTestId } = await render(<ReportsScreen />);
+    await waitFor(() => expect(mockFetchBasicReports).toHaveBeenCalled());
+
+    await fireEvent.press(getByText('Análise de Negócio'));
+    await waitFor(() => expect(mockFetchRevenue).toHaveBeenCalled());
+
+    // Chart view by default: no table rendered yet.
+    expect(queryByTestId('revenue-table')).toBeNull();
+
+    await fireEvent.press(getByTestId('revenue-view-table'));
+
+    expect(getByTestId('revenue-table')).toBeTruthy();
+    expect(getByText('Período')).toBeTruthy();
+    expect(getByText('Receita')).toBeTruthy();
+    expect(getByText('15/06')).toBeTruthy();
+    expect(getByText('22/06')).toBeTruthy();
+    expect(getByText('300,00 €')).toBeTruthy();
+    expect(getByText('500,00 €')).toBeTruthy();
+    expect(getByText('10')).toBeTruthy();
+    expect(getByText('15')).toBeTruthy();
+
+    await fireEvent.press(getByTestId('revenue-view-chart'));
+    expect(queryByTestId('revenue-table')).toBeNull();
+  });
+
+  it('opens the Profissional filter in a modal and applies the selection via the picker inside it', async () => {
+    const { getByText, getAllByText, getByTestId, queryByTestId } = await render(<ReportsScreen />);
+    await waitFor(() => expect(mockFetchBasicReports).toHaveBeenCalled());
+
+    await fireEvent.press(getByText('Análise de Negócio'));
+    await waitFor(() => expect(mockFetchTopServices).toHaveBeenCalled());
+
+    await fireEvent.press(getByTestId('toggle-filters'));
+
+    // Picker is not rendered inline; it lives inside the trigger's modal.
+    expect(queryByTestId('reports-professional-picker')).toBeNull();
+    // Both triggers ("Profissional" and "Serviço") default to "Todos".
+    expect(getAllByText('Todos').length).toBe(2);
+
+    await fireEvent.press(getByTestId('reports-professional-picker-trigger'));
+    await selectPickerValue(getByTestId, 'reports-professional-picker', '1', 0);
+    await fireEvent.press(getByText('Concluir'));
+
+    await fireEvent.press(getByTestId('reports-service-picker-trigger'));
+    await selectPickerValue(getByTestId, 'reports-service-picker', '9', 0);
+    await fireEvent.press(getByText('Concluir'));
+
+    await fireEvent.press(getByText('Aplicar filtros'));
+
+    await waitFor(() => {
+      expect(mockFetchTopServices).toHaveBeenLastCalledWith(
+        expect.objectContaining({ professionalId: '1', serviceId: '9' })
+      );
+    });
+    expect(mockFetchRevenue).toHaveBeenCalled();
   });
 
   it('exports the basic report CSV and shares it', async () => {


### PR DESCRIPTION
- Período padrão = mês atual; painel de filtros de data (reaproveita DatePickerInput), antes inexistente no ecrã de Relatórios.
- Seletores de Intervalo de Tempo e Itens por Página na aba Análise de Negócio, agora ligados de facto aos pedidos à API.
- Filtros de Profissional (Análise + Insights) e Serviço (Análise), usando um trigger compacto que abre um modal com o picker — evita o wheel nativo do iOS a ocupar ~200px fixos por 3-4 opções.
- Corrige bug real: o ecrã esperava as respostas de top-services/ revenue num envelope ({ top_services: [...] } / { revenue: { series } }) que a API nunca devolveu (é array puro / { series } direto) — por isso ambas as secções ficavam sempre vazias mesmo com dados reais. Os testes tinham o mesmo formato errado no mock, por isso não apanhavam o bug.
- Abas Análise/Insights: estado vazio, erro de rede com retry, e aviso de plano não incluído passam a ser distintos (antes: um só Alert genérico e ecrã em branco).
- Toggle Gráfico/Tabela em "Receita por {intervalo}", como no FEW.
- Ajuste de espaçamento das barras do gráfico de receita.